### PR TITLE
Corrigir relacionamento entre Guilda e Membro 

### DIFF
--- a/src/main/java/com/br/zup/gerenciadordeguildas/dtos/entrada/membro/MembroDTO.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/dtos/entrada/membro/MembroDTO.java
@@ -7,7 +7,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.Email;
-import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 
@@ -22,7 +21,6 @@ public class MembroDTO {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
     @NotNull
-    @Min(3)
     private String nome;
     @Email(message = "Email inválido!")
     private String email;
@@ -31,5 +29,5 @@ public class MembroDTO {
     @NotNull
     private boolean representante;
     @NotNull
-    private List<Integer> guildas;
+    private List<Guilda> guildas;
 }

--- a/src/main/java/com/br/zup/gerenciadordeguildas/entities/Guilda.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/entities/Guilda.java
@@ -20,7 +20,7 @@ public class Guilda {
     private String objetivos;
     private String linkDoChat;
 
-    @OneToMany
+    @ManyToMany(mappedBy = "guildas")
     private List<Membro> membros;
 
     @OneToMany

--- a/src/main/java/com/br/zup/gerenciadordeguildas/entities/Membro.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/entities/Membro.java
@@ -20,7 +20,7 @@ public class Membro {
     private String email;
     private String zenity;
     private boolean representante;
-    @OneToMany
+    @ManyToMany(fetch = FetchType.EAGER)
     private List<Guilda> guildas;
 
 }

--- a/src/main/java/com/br/zup/gerenciadordeguildas/entities/Membro.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/entities/Membro.java
@@ -21,6 +21,10 @@ public class Membro {
     private String zenity;
     private boolean representante;
     @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(
+            name = "membros_guildas",
+            joinColumns = @JoinColumn(name = "membro_id"),
+            inverseJoinColumns = @JoinColumn(name = "guilda_id"))
     private List<Guilda> guildas;
 
 }

--- a/src/main/java/com/br/zup/gerenciadordeguildas/services/GuildaService.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/services/GuildaService.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.List;
 
@@ -45,10 +46,13 @@ public class GuildaService {
         List<Guilda> listaDeGuildas = new ArrayList<>();
 
         for (Guilda guilda : guildas) {
-            if(guildaRepository.existsById(guilda.getId())){
-                listaDeGuildas.add(guilda);
+           Optional<Guilda> objGuilda = guildaRepository.findById(guilda.getId());
+           if(Objects.nonNull(objGuilda)){
+               listaDeGuildas.add(guilda);
+            }else{
+                throw new RecursoNaoEncontradoException("Guilda", guilda.getId());
+
             }
-            throw new RecursoNaoEncontradoException("Guilda", guilda.getId());
         }
 
         return listaDeGuildas;

--- a/src/main/java/com/br/zup/gerenciadordeguildas/services/MembroService.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/services/MembroService.java
@@ -21,7 +21,7 @@ public class MembroService {
 
     public Membro cadastrarMembro(Membro membro) {
         listaDeGuildasDoMembro = guildaService.buscarGuildas(membro.getGuildas());
-        verificarSeMembroERepresentanteEEstaEmMaisDeUmaGuilda(membro);
+      // todo: rever regra - verificarSeMembroERepresentanteEEstaEmMaisDeUmaGuilda(membro);
         membro.setGuildas(listaDeGuildasDoMembro);
         return membroRepository.save(membro);
     }
@@ -40,7 +40,7 @@ public class MembroService {
     }
 
     public void verificarSeMembroERepresentanteEEstaEmMaisDeUmaGuilda(Membro membro){
-        if(listaDeGuildasDoMembro.stream().count() > 0 && membro.isRepresentante() == true){
+        if(listaDeGuildasDoMembro.stream().count() > 0 && membro.isRepresentante()){
             throw new RuntimeException("O membro só pode ser representante de uma guilda");
         }
     }


### PR DESCRIPTION
Implementações realizadas: 

- Foi corrigido o mapeamento entre as entidades Guilda e Membro que devem ser ManyToMany
- Incluído o JoinTable em Membro, que evita a construção de duas tabelas (membros_guildas  e guildas_membros, construindo somente membros_guildas)
- Realizar o mapeamento em Guilda, incluindo o atributo guildas que é mapeado dentro de Membro
- O método para verificar se o membro é representante e faz parte de mais de uma guilda foi colocado em comentado dentro de cadastrar membro, pois devemos rever a regra de negócio que não permite identificar de qual guilda o membro é representante.
- O tipo da lista de Guilda, foi alterado de Integer para Guilda


Observação: O método cadastrar membro está funcionando, porém no "save" está dando problema, ao debugar pude notar que antes de salvar os atributos de guilda ficam nulos (exceto o Id passado pelo usuário).