### PR TITLE
Implementar cadastro de ata

### DIFF
--- a/src/main/java/com/br/zup/gerenciadordeguildas/controllers/AtaController.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/controllers/AtaController.java
@@ -1,9 +1,12 @@
 package com.br.zup.gerenciadordeguildas.controllers;
 
-import com.br.zup.gerenciadordeguildas.dtos.entrada.ata.AtaDTO;
+import com.br.zup.gerenciadordeguildas.dtos.entrada.ata.CadastroAtaDTO;
 import com.br.zup.gerenciadordeguildas.dtos.entrada.ata.AtualizarAtaDTO;
+import com.br.zup.gerenciadordeguildas.dtos.saida.ata.CadastroAtaDTOSaida;
 import com.br.zup.gerenciadordeguildas.entities.Ata;
+import com.br.zup.gerenciadordeguildas.entities.Guilda;
 import com.br.zup.gerenciadordeguildas.services.AtaService;
+import com.br.zup.gerenciadordeguildas.services.GuildaService;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -15,20 +18,22 @@ import javax.validation.Valid;
 public class AtaController {
 
     private AtaService ataService;
+    private GuildaService guildaService;
     private ModelMapper modelMapper;
 
-    public AtaController(AtaService ataService, ModelMapper modelMapper) {
+    public AtaController(AtaService ataService, GuildaService guildaService, ModelMapper modelMapper) {
         this.ataService = ataService;
+        this.guildaService = guildaService;
         this.modelMapper = modelMapper;
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public AtaDTO cadastrarAta(@RequestBody @Valid AtaDTO ataDTO) {
-        Ata ata = modelMapper.map(ataDTO, Ata.class);
-        ata = ataService.cadastrarAta(ata);
+    public CadastroAtaDTOSaida cadastrarAta(@RequestBody @Valid CadastroAtaDTO cadastroAtaDTO) {
+        Guilda guilda = guildaService.buscarGuildaPeloNome(cadastroAtaDTO.getGuilda());
+        Ata ata = ataService.cadastrarAta(cadastroAtaDTO.converterDTOParaEntity(guilda));
 
-        return modelMapper.map(ata, AtaDTO.class);
+        return CadastroAtaDTOSaida.converterEntityParaDTOSaida(ata);
     }
 
     @GetMapping("/")

--- a/src/main/java/com/br/zup/gerenciadordeguildas/dtos/entrada/ata/AtaDTO.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/dtos/entrada/ata/AtaDTO.java
@@ -24,5 +24,6 @@ public class AtaDTO {
     @Size(max = 500, message = "Digitar no máximo 500 caracteres.")
     private String assuntos;
 
+    private String guilda;
 
 }

--- a/src/main/java/com/br/zup/gerenciadordeguildas/dtos/entrada/ata/CadastroAtaDTO.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/dtos/entrada/ata/CadastroAtaDTO.java
@@ -1,5 +1,7 @@
 package com.br.zup.gerenciadordeguildas.dtos.entrada.ata;
 
+import com.br.zup.gerenciadordeguildas.entities.Ata;
+import com.br.zup.gerenciadordeguildas.entities.Guilda;
 import lombok.*;
 
 import javax.validation.constraints.NotNull;
@@ -11,7 +13,7 @@ import java.time.LocalDate;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class AtaDTO {
+public class CadastroAtaDTO {
 
     private Integer id;
     private LocalDate data;
@@ -26,4 +28,14 @@ public class AtaDTO {
 
     private String guilda;
 
+    public Ata converterDTOParaEntity(Guilda guilda){
+        Ata ata = new Ata();
+        ata.setId(this.id);
+        ata.setData(LocalDate.now());
+        ata.setAssuntos(this.assuntos);
+        ata.setPauta(this.pauta);
+        ata.setGuilda(guilda);
+
+        return ata;
+    }
 }

--- a/src/main/java/com/br/zup/gerenciadordeguildas/dtos/saida/ata/CadastroAtaDTOSaida.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/dtos/saida/ata/CadastroAtaDTOSaida.java
@@ -1,0 +1,41 @@
+package com.br.zup.gerenciadordeguildas.dtos.saida.ata;
+
+import com.br.zup.gerenciadordeguildas.entities.Ata;
+import com.br.zup.gerenciadordeguildas.entities.Guilda;
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CadastroAtaDTOSaida {
+
+    private Integer id;
+    private LocalDate data;
+
+    @NotNull
+    @Size(max = 30, message = "Digitar no máximo 30 caracteres.")
+    private String pauta;
+
+    @NotNull
+    @Size(max = 500, message = "Digitar no máximo 500 caracteres.")
+    private String assuntos;
+
+    private Guilda guilda;
+
+    public static CadastroAtaDTOSaida converterEntityParaDTOSaida(Ata ata) {
+        CadastroAtaDTOSaida cadastroAtaDTOSaida = new CadastroAtaDTOSaida();
+        cadastroAtaDTOSaida.setId(ata.getId());
+        cadastroAtaDTOSaida.setPauta(ata.getPauta());
+        cadastroAtaDTOSaida.setData(ata.getData());
+        cadastroAtaDTOSaida.setAssuntos(ata.getAssuntos());
+        cadastroAtaDTOSaida.setGuilda(ata.getGuilda());
+
+        return cadastroAtaDTOSaida;
+    }
+}


### PR DESCRIPTION
Foi corrigido o método de cadastrar ata, que não estava funcionando porque não relacionava-se com a guilda desejada.

- Antiga AtaDTO se transformou em CadastroAtaDTO
- Foi criada a DTO CadastroAtaDTOSaida
- O relacionamento entre Ata e Guilda foi adicionado nas classes DTOs