### PR TITLE
Adicionar anotações do lombok em AtualizarMembroDTO

### DIFF
--- a/src/main/java/com/br/zup/gerenciadordeguildas/dtos/entrada/membro/AtualizarMembroDTO.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/dtos/entrada/membro/AtualizarMembroDTO.java
@@ -2,12 +2,18 @@ package com.br.zup.gerenciadordeguildas.dtos.entrada.membro;
 
 import com.br.zup.gerenciadordeguildas.entities.Guilda;
 import com.br.zup.gerenciadordeguildas.entities.Membro;
+import lombok.*;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.List;
 
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class AtualizarMembroDTO {
 
     @NotNull


### PR DESCRIPTION
O método put de membro não estava funcionando devidamente, estava alterando todos campos para null. Isso ocorria devido a falta das anotações @ do lombok que foram inclusas agora.