### PR TITLE
Adicionar metodo interceptador methodArgumentNotValidException

### DIFF
--- a/src/main/java/com/br/zup/gerenciadordeguildas/exceptions/ManipuladorDeExcecoes.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/exceptions/ManipuladorDeExcecoes.java
@@ -2,6 +2,7 @@ package com.br.zup.gerenciadordeguildas.exceptions;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -22,6 +23,23 @@ public class ManipuladorDeExcecoes {
                 status.value(),
                 error,
                 exception.getMessage(),
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(status).body(err);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<MensagemDeErro> methodArgumentNotValidException(
+            MethodArgumentNotValidException exception,
+            HttpServletRequest request) {
+        System.out.println(exception.toString());
+        String error = "Bad request";
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        MensagemDeErro err = new MensagemDeErro(
+                Instant.now(),
+                status.value(),
+                error,
+                exception.getFieldError().getDefaultMessage(),
                 request.getRequestURI()
         );
         return ResponseEntity.status(status).body(err);


### PR DESCRIPTION
Corrigido o erro do Spring Validation, acrescentando o método interceptador methodArgumentNotValidException na classe ManipuladorDeExcecoes.