### PR TITLE
Corrigir relacionamento entre Membro com Guilda 

### DIFF
--- a/src/main/java/com/br/zup/gerenciadordeguildas/controllers/AtividadeController.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/controllers/AtividadeController.java
@@ -1,10 +1,9 @@
 package com.br.zup.gerenciadordeguildas.controllers;
 
+import com.br.zup.gerenciadordeguildas.dtos.entrada.atividade.AtualizarParcialAtividadeDTO;
 import com.br.zup.gerenciadordeguildas.dtos.entrada.atividade.CadastroAtividadeDTO;
-import com.br.zup.gerenciadordeguildas.dtos.entrada.atividade.AtualizacaoParcialAtividadeDTO;
 import com.br.zup.gerenciadordeguildas.dtos.entrada.atividade.AtualizarAtividadeDTO;
 import com.br.zup.gerenciadordeguildas.dtos.saida.atividade.CadastroAtividadeDTOSaida;
-import com.br.zup.gerenciadordeguildas.entities.Ata;
 import com.br.zup.gerenciadordeguildas.entities.Atividade;
 import com.br.zup.gerenciadordeguildas.entities.Guilda;
 import com.br.zup.gerenciadordeguildas.entities.Membro;
@@ -64,7 +63,7 @@ public class AtividadeController {
 
     @PatchMapping("{id}/")
     public Atividade atualizarAtividadeParcial(@PathVariable int id,
-                                               @RequestBody @Valid AtualizacaoParcialAtividadeDTO atividadeDTO){
+                                               @RequestBody @Valid AtualizarParcialAtividadeDTO atividadeDTO){
         Atividade atividade = atividadeDTO.converterDTOParaModel(id);
         return atividadeService.atualizarParcialAtividade(atividade);
     }

--- a/src/main/java/com/br/zup/gerenciadordeguildas/controllers/MembroController.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/controllers/MembroController.java
@@ -32,10 +32,8 @@ public class MembroController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public CadastroMembroDTOSaida cadastrarMembro(@RequestBody @Valid CadastroMembroDTO cadastroMembroDTO){
-        List<Guilda> guildas = new ArrayList<>();
-        cadastroMembroDTO.getGuildas()
-                         .forEach( nomeDaGuilda -> guildas.add(guildaService.buscarGuildaPeloNome(nomeDaGuilda)));
-        Membro membro = membroService.cadastrarMembro(cadastroMembroDTO.converterDTOparaEntity(guildas));
+        Guilda guilda = guildaService.buscarGuildaPeloNome(cadastroMembroDTO.getGuilda());
+        Membro membro = membroService.cadastrarMembro(cadastroMembroDTO.converterDTOparaEntity(guilda));
 
         return CadastroMembroDTOSaida.converterEntityParaDTOSaida(membro);
     }

--- a/src/main/java/com/br/zup/gerenciadordeguildas/dtos/entrada/membro/CadastroMembroDTO.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/dtos/entrada/membro/CadastroMembroDTO.java
@@ -1,6 +1,5 @@
 package com.br.zup.gerenciadordeguildas.dtos.entrada.membro;
 
-import com.br.zup.gerenciadordeguildas.dtos.saida.membro.CadastroMembroDTOSaida;
 import com.br.zup.gerenciadordeguildas.entities.Guilda;
 import com.br.zup.gerenciadordeguildas.entities.Membro;
 import lombok.*;
@@ -27,15 +26,15 @@ public class CadastroMembroDTO {
     @NotNull
     private boolean representante;
     @NotNull
-    private List<String> guildas;
+    private String guilda;
 
-    public Membro converterDTOparaEntity(List<Guilda> guildas) {
+    public Membro converterDTOparaEntity(Guilda guilda) {
         Membro membro = new Membro();
         membro.setNome(this.nome);
         membro.setEmail(this.email);
         membro.setZenity(this.zenity);
         membro.setRepresentante(this.representante);
-        membro.setGuildas(guildas);
+        membro.setGuilda(guilda);
 
         return membro;
     }

--- a/src/main/java/com/br/zup/gerenciadordeguildas/dtos/saida/membro/CadastroMembroDTOSaida.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/dtos/saida/membro/CadastroMembroDTOSaida.java
@@ -17,7 +17,7 @@ public class CadastroMembroDTOSaida {
         private String email;
         private String zenity;
         private boolean representante;
-        private List<Guilda> guildas;
+        private Guilda guilda;
 
         public static CadastroMembroDTOSaida converterEntityParaDTOSaida(Membro membro) {
             CadastroMembroDTOSaida cadastroMembroDTOSaida = new CadastroMembroDTOSaida();
@@ -25,8 +25,8 @@ public class CadastroMembroDTOSaida {
             cadastroMembroDTOSaida.setNome(membro.getNome());
             cadastroMembroDTOSaida.setEmail(membro.getEmail());
             cadastroMembroDTOSaida.setZenity(membro.getZenity());
-            cadastroMembroDTOSaida.setRepresentante(membro.getRepresentante());
-            cadastroMembroDTOSaida.setGuildas(membro.getGuildas());
+            cadastroMembroDTOSaida.setRepresentante(membro.isRepresentante());
+            cadastroMembroDTOSaida.setGuilda(membro.getGuilda());
 
             return cadastroMembroDTOSaida;
         }

--- a/src/main/java/com/br/zup/gerenciadordeguildas/entities/Guilda.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/entities/Guilda.java
@@ -23,7 +23,7 @@ public class Guilda {
     private String linkDoChat;
 
     @JsonIgnore
-    @ManyToMany(fetch = FetchType.EAGER)
+    @OneToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "guildas_membros",
     joinColumns = @JoinColumn(name = "guildas_id"),
     inverseJoinColumns = @JoinColumn(name = "membros_id"))

--- a/src/main/java/com/br/zup/gerenciadordeguildas/entities/Membro.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/entities/Membro.java
@@ -5,7 +5,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.util.List;
 
 @Entity
 @Data
@@ -20,9 +19,9 @@ public class Membro {
     private String nome;
     private String email;
     private String zenity;
-    private Boolean representante;
+    private boolean representante;
     @JsonIgnore
-    @ManyToMany(mappedBy = "membros")
+    @ManyToOne
     private Guilda guilda;
 
 }

--- a/src/main/java/com/br/zup/gerenciadordeguildas/entities/Membro.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/entities/Membro.java
@@ -23,6 +23,6 @@ public class Membro {
     private Boolean representante;
     @JsonIgnore
     @ManyToMany(mappedBy = "membros")
-    private List<Guilda> guildas;
+    private Guilda guilda;
 
 }

--- a/src/main/java/com/br/zup/gerenciadordeguildas/exceptions/EmailExistenteException.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/exceptions/EmailExistenteException.java
@@ -1,6 +1,6 @@
 package com.br.zup.gerenciadordeguildas.exceptions;
 
-public class EmailExistenteException extends RuntimeException{
+public class EmailExistenteException extends RuntimeException {
     public EmailExistenteException() {
         super("Membro já cadastrado com este e-mail!");
     }

--- a/src/main/java/com/br/zup/gerenciadordeguildas/exceptions/EmailExistenteException.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/exceptions/EmailExistenteException.java
@@ -1,0 +1,7 @@
+package com.br.zup.gerenciadordeguildas.exceptions;
+
+public class EmailExistenteException extends RuntimeException{
+    public EmailExistenteException() {
+        super("Membro já cadastrado com este e-mail!");
+    }
+}

--- a/src/main/java/com/br/zup/gerenciadordeguildas/exceptions/ManipuladorDeExcecoes.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/exceptions/ManipuladorDeExcecoes.java
@@ -91,5 +91,4 @@ public class ManipuladorDeExcecoes {
         );
         return ResponseEntity.status(status).body(err);
     }
-
 }

--- a/src/main/java/com/br/zup/gerenciadordeguildas/exceptions/ManipuladorDeExcecoes.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/exceptions/ManipuladorDeExcecoes.java
@@ -76,4 +76,20 @@ public class ManipuladorDeExcecoes {
         return ResponseEntity.status(status).body(err);
     }
 
+    @ExceptionHandler(EmailExistenteException.class)
+    public ResponseEntity<MensagemDeErro> emailExistenteException(
+            EmailExistenteException exception,
+            HttpServletRequest request) {
+        String error = "Bad request";
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        MensagemDeErro err = new MensagemDeErro(
+                Instant.now(),
+                status.value(),
+                error,
+                exception.getMessage(),
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(status).body(err);
+    }
+
 }

--- a/src/main/java/com/br/zup/gerenciadordeguildas/repositories/MembroRepository.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/repositories/MembroRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface MembroRepository extends CrudRepository<Membro,Integer> {
     Optional<Membro> findByNome(String nome);
     Optional<Membro> findByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/br/zup/gerenciadordeguildas/services/MembroService.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/services/MembroService.java
@@ -34,7 +34,7 @@ public class MembroService {
             return optionalMembro.get();
         }
 
-        throw new RuntimeException("Membro não existe");
+        throw new RecursoNaoEncontradoException("Membro", id);
     }
 
     public Membro buscarMembroPeloEmail(String email){

--- a/src/main/java/com/br/zup/gerenciadordeguildas/services/MembroService.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/services/MembroService.java
@@ -24,7 +24,6 @@ public class MembroService {
 
     public Membro cadastrarMembro(Membro membro) {
         try{ listaDeGuildasDoMembro = guildaService.buscarGuildas(membro.getGuildas());
-            // todo: rever regra - verificarSeMembroERepresentanteEEstaEmMaisDeUmaGuilda(membro);
             membro.setGuildas(listaDeGuildasDoMembro);
             return membroRepository.save(membro);}
         catch (Exception error){
@@ -96,6 +95,14 @@ public class MembroService {
 
         } catch (Exception error){
             throw new RecursoNaoEncontradoException("Membro", membroParaAtualizar.getId());}
+    }
+
+    public boolean verificarEmailCadastrado(String email){
+        if(!membroRepository.existsByEmail(email)){
+            return true;
+        } else {
+            throw new RuntimeException("Membro já cadastrado com esse e-mail!");
+        }
     }
 //
 //    public void verificarSeMembroERepresentanteEEstaEmMaisDeUmaGuilda(Membro membro){

--- a/src/main/java/com/br/zup/gerenciadordeguildas/services/MembroService.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/services/MembroService.java
@@ -1,13 +1,11 @@
 package com.br.zup.gerenciadordeguildas.services;
 
-import com.br.zup.gerenciadordeguildas.entities.Guilda;
 import com.br.zup.gerenciadordeguildas.entities.Membro;
 import com.br.zup.gerenciadordeguildas.exceptions.ListaVaziaException;
 import com.br.zup.gerenciadordeguildas.exceptions.RecursoNaoEncontradoException;
 import com.br.zup.gerenciadordeguildas.repositories.MembroRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import java.util.List;
 
 import java.util.Optional;
 
@@ -20,15 +18,12 @@ public class MembroService {
     @Autowired
     private GuildaService guildaService;
 
-    List<Guilda> listaDeGuildasDoMembro;
-
     public Membro cadastrarMembro(Membro membro) {
-        try{ listaDeGuildasDoMembro = guildaService.buscarGuildas(membro.getGuildas());
-            membro.setGuildas(listaDeGuildasDoMembro);
-            return membroRepository.save(membro);}
-        catch (Exception error){
-            throw new RuntimeException("Não foi posssível cadastrar membro!");
-        }
+        verificarEmailCadastrado(membro.getEmail());
+        Membro objMembro = membroRepository.save(membro);
+        guildaService.adicionarMembroNaGuilda(membro.getGuilda().getId(), membro.getId());
+
+        return objMembro;
     }
 
     public Membro buscarMembroPeloId(int id){
@@ -87,8 +82,8 @@ public class MembroService {
                 membroAtualNoBD.setZenity(membroParaAtualizar.getZenity());
             }
 
-            if (membroAtualNoBD.getRepresentante() != membroParaAtualizar.getRepresentante() && membroParaAtualizar.getRepresentante() != null){
-                membroAtualNoBD.setRepresentante(membroParaAtualizar.getRepresentante());
+            if (membroAtualNoBD.isRepresentante() != membroParaAtualizar.isRepresentante()){
+                membroAtualNoBD.setRepresentante(membroParaAtualizar.isRepresentante());
             }
 
             return atualizarMembro(membroAtualNoBD);

--- a/src/main/java/com/br/zup/gerenciadordeguildas/services/MembroService.java
+++ b/src/main/java/com/br/zup/gerenciadordeguildas/services/MembroService.java
@@ -1,6 +1,7 @@
 package com.br.zup.gerenciadordeguildas.services;
 
 import com.br.zup.gerenciadordeguildas.entities.Membro;
+import com.br.zup.gerenciadordeguildas.exceptions.EmailExistenteException;
 import com.br.zup.gerenciadordeguildas.exceptions.ListaVaziaException;
 import com.br.zup.gerenciadordeguildas.exceptions.RecursoNaoEncontradoException;
 import com.br.zup.gerenciadordeguildas.repositories.MembroRepository;
@@ -96,7 +97,7 @@ public class MembroService {
         if(!membroRepository.existsByEmail(email)){
             return true;
         } else {
-            throw new RuntimeException("Membro já cadastrado com esse e-mail!");
+            throw new EmailExistenteException();
         }
     }
 //


### PR DESCRIPTION
- Foi criado o método para validar se o e-mail já está cadastrado para não adicionar um repetido.
- Foi corrigido o relacionamento entre membro e guildas, no qual agora o membro só pode se inscrever em uma única guilda.